### PR TITLE
Image upload feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+/src/minio-storage/data-volume/

--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -12,15 +12,28 @@ services:
     - GATCHA_URL=http://gatcha:5000
     - USER_URL=http://user:5000
     - MARKET_URL=http://market:5000
+    - MINIO_STORAGE_URL=http://minio-storage:9000
+
+
 
   # Gatcha service
   gatcha:
     build: ./gatcha
     depends_on:
       - db-gatcha
+      - minio-storage
+      - user
     environment:
       - USER_URL=http://user:5000
       - MARKET_URL=http://market:5000
+
+      - MINIO_STORAGE_URL=minio-storage:9000 # non mettere http:// o https:// perché lo mette da solo il client minio
+      - MINIO_STORAGE_ACCESS_KEY=minioadmin
+      - MINIO_STORAGE_SECRET_KEY=minioadmin
+      - MINIO_STORAGE_BUCKET_NAME=gachabucket
+
+
+
 
   # User Service
   user:
@@ -71,6 +84,29 @@ services:
     environment:
       MONGO_INITDB_DATABASE: market_db
     command: mongod --quiet --logpath /dev/null
+
+
+
+
+
+
+  # a service to store files (images, etc.) in a bucket (like AWS S3)
+  # documentation: https://github.com/minio/minio?tab=readme-ov-file#container-installation
+  minio-storage:
+    image: quay.io/minio/minio   # The MinIO image
+    container_name: minio-storage-container        # Optional: Name your container
+    ports:
+      - "9000:9000"              # MinIO API
+      - "9001:9001"              # MinIO Console
+    environment:
+      MINIO_ROOT_USER: minioadmin # Access Key (Admin User)
+      MINIO_ROOT_PASSWORD: minioadmin # Secret Key (Admin Password)
+    command: server /data --console-address ":9001"  # Command to start the MinIO server
+    volumes:
+      - ./minio-storage/data-volume:/data             # Persist data on the host machine
+
+
+
 
 volumes:
   dbdata-gatcha:

--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -73,7 +73,7 @@ services:
       - dbdata-user:/data/db
     environment:
       MONGO_INITDB_DATABASE: user_db  # Nome del database per gli utenti
-    command: mongod --quiet --logpath /dev/null  # Avvia MongoDB con log minimizzati
+    command: mongod --quiet --logpath /var/log/mongodb/mongod.log  # Avvia MongoDB con log minimizzati
 
   db-market:
     image: mongo:latest

--- a/src/gatcha/Dockerfile
+++ b/src/gatcha/Dockerfile
@@ -3,11 +3,14 @@ FROM python:3.9-slim
 # Imposta la directory di lavoro nel container
 WORKDIR /app
 
-# Copia i file del progetto nel container
-COPY . /app
+# Copia solo il file delle dipendenze prima
+COPY requirements.txt /app/
 
 # Installa le dipendenze necessarie
 RUN pip install --no-cache-dir -r requirements.txt
+
+# Copia i file del progetto nel container
+COPY . /app
 
 # Esponi la porta su cui l'app Flask girerà (5000)
 EXPOSE 5000

--- a/src/gatcha/app.py
+++ b/src/gatcha/app.py
@@ -145,6 +145,7 @@ def insert_data_to_db(client, db_name, collection_name, data):
 # Endpoint per aggiungere dati nel database gacha_db
 # TODO: aggiungere input validation per controllare che la richiesta sia come ce lo aspettiamo
 # TODO: può farla solo admin
+# TODO: c'è un test già scritto, spostarlo in integration tests
 @app.route('/addgatchaData', methods=['POST'])
 def add_gatcha_data():
     """

--- a/src/gatcha/app.py
+++ b/src/gatcha/app.py
@@ -1,9 +1,23 @@
+import datetime
 import os
 import random
 from flask import Flask, request, make_response
 from pymongo import MongoClient
 from pymongo.errors import ServerSelectionTimeoutError
 import bson.json_util as json_util
+
+
+# for handling image uploads to MinIO
+from werkzeug.utils import secure_filename
+from minio import Minio
+from minio.error import S3Error
+
+# for better error messages
+from rich.traceback import install
+install(show_locals=True)
+
+
+
 
 RARITY_PROBABILITIES = {
     'comune': 0.5,       # 50%
@@ -12,9 +26,81 @@ RARITY_PROBABILITIES = {
     'leggendario': 0.05  # 5%
 }
 
+
 # URLS dei microservizi
 USER_URL = os.getenv('USER_URL')
 MARKET_URL = os.getenv('MARKET_URL')
+MINIO_STORAGE_URL = os.getenv('MINIO_STORAGE_URL')
+
+# MinIO/S3 settings
+MINIO_STORAGE_ACCESS_KEY = os.getenv("MINIO_STORAGE_ACCESS_KEY")
+MINIO_STORAGE_SECRET_KEY = os.getenv("MINIO_STORAGE_SECRET_KEY")
+MINIO_STORAGE_BUCKET_NAME = os.getenv("MINIO_STORAGE_BUCKET_NAME")
+
+def validate_env_vars(**vars):
+    for name, value in vars.items():
+        if not value or not isinstance(value, str):
+            raise ValueError(f"Environment variable {name} with value {value} is not set or is not a valid string.")
+
+# Validate required environment variables
+validate_env_vars(
+    USER_URL=USER_URL,
+    MARKET_URL=MARKET_URL,
+    MINIO_STORAGE_URL=MINIO_STORAGE_URL,
+    MINIO_STORAGE_ACCESS_KEY=MINIO_STORAGE_ACCESS_KEY,
+    MINIO_STORAGE_SECRET_KEY=MINIO_STORAGE_SECRET_KEY,
+    MINIO_STORAGE_BUCKET_NAME=MINIO_STORAGE_BUCKET_NAME
+)
+
+
+
+
+
+# region Configurazione MinIO/S3 ----------------------------------------
+
+# Configure S3 client
+minio_client = Minio(MINIO_STORAGE_URL,
+    access_key=MINIO_STORAGE_ACCESS_KEY,
+    secret_key=MINIO_STORAGE_SECRET_KEY,
+    secure=False # se mettiamo True, aggiunge "https://" all'inizio dell'URL. Se metti False, aggiunge "http://"
+)
+
+def create_bucket(bucket_name):
+    
+    read_only_policy = {
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Effect": "Allow",
+                "Principal": {"AWS": "*"},
+                "Action": ["s3:GetBucketLocation", "s3:ListBucket"],
+                "Resource": "arn:aws:s3:::my-bucket",
+            },
+            {
+                "Effect": "Allow",
+                "Principal": {"AWS": "*"},
+                "Action": "s3:GetObject",
+                "Resource": "arn:aws:s3:::my-bucket/*",
+            },
+        ],
+    }
+    
+    
+    found = minio_client.bucket_exists(bucket_name)
+    if not found:
+        minio_client.make_bucket(bucket_name)
+        print("Created bucket", bucket_name)
+        minio_client.set_bucket_policy(bucket_name, read_only_policy)  # Shortcut for read-only
+        print("Bucket policy set to public")
+    else:
+        print("Bucket", bucket_name, "already exists")
+
+try:
+    create_bucket(MINIO_STORAGE_BUCKET_NAME)
+except S3Error as e:
+    print("Error while creating the bucker", e)
+# endregion Configurazione MinIO/S3 ----------------------------------------
+
 
 # Connessione ai database dei microservizi (modificato per usare i container MongoDB tramite nome servizio)
 client_gatcha = MongoClient("db-gatcha", 27017, maxPoolSize=50)
@@ -41,15 +127,65 @@ def insert_data_to_db(client, db_name, collection_name, data):
     collection = db[collection_name]
     collection.insert_one(data)
 
+
+
+
+
 # Endpoint per aggiungere dati nel database gacha_db
+# TODO: aggiungere input validation per controllare che la richiesta sia come ce lo aspettiamo
 @app.route('/addgatchaData', methods=['POST'])
 def add_gatcha_data():
-    data = request.json
+    if 'file' not in request.files or 'json' not in request.form:
+        return make_response(json_util.dumps({"error": "Both image file and JSON payload are required in the same request"}), 400)
+
+    file = request.files['file']
+
+    if file.filename == '':
+        return make_response(json_util.dumps({"error": "No image file uploaded"}), 400)
+
+    filename = secure_filename(file.filename)
+    filename = f"{datetime.datetime.now().strftime('%Y%m%d%H%M%S')}_{filename}"
+    destination_file_path = f"images/{filename}"
+
     try:
-        insert_data_to_db(client_gatcha, 'db-gatcha', 'db_gatcha', data) 
-        return make_response(json_util.dumps({"message": "Data added to gatcha_db"}), 200)
+        # Save the file to a temporary location
+        temp_file_path = os.path.join('/tmp', filename)
+        file.save(temp_file_path)
+
+        # Upload the file to MinIO
+        minio_client.fput_object(
+            bucket_name=MINIO_STORAGE_BUCKET_NAME, 
+            object_name=destination_file_path, 
+            file_path=temp_file_path,
+        )
+        print(
+            f"File '{file.filename}' successfully uploaded as '{destination_file_path}' to bucket '{MINIO_STORAGE_BUCKET_NAME}'"
+        )
+        image_url = f"/storage/{MINIO_STORAGE_BUCKET_NAME}/images/{filename}"
     except Exception as e:
-        return make_response(str(e), 500)
+        app.logger.error(f"Failed to upload image: {str(e)}")
+        return make_response(json_util.dumps({"error": "Failed to upload image"}), 500)
+    finally:
+        # Clean up the temporary file
+        if os.path.exists(temp_file_path):
+            os.remove(temp_file_path)
+
+    try:
+        data = json_util.loads(request.form.get('json'))
+    except Exception as e:
+        return make_response(json_util.dumps({"error": "Invalid JSON format provided"}), 400)
+
+    data['image'] = image_url
+
+    try:
+        insert_data_to_db(client_gatcha, 'db-gatcha', 'db_gatcha', data)
+        return make_response(json_util.dumps({"message": "Data with image added to gatcha_db", "data": data}), 200)
+    except Exception as e:
+        return make_response(json_util.dumps({"error": f"Database insert failed: {str(e)}"}), 500)
+
+
+
+
 
 
 # Endpoint per rollare un gatcha
@@ -61,7 +197,7 @@ def roll_gatcha():
         
         # Query al database per ottenere un personaggio della rarità selezionata
         gachas = list(client_gatcha['gatcha_db']['gatchas'].find({"rarity": selected_rarity}))
-       
+
         if not gachas:
             return make_response(f"No character found for rarity {selected_rarity}\n", 404)
         # Estrai un personaggio randomico dalla lista dei personaggi della rarità selezionata

--- a/src/gatcha/requirements.txt
+++ b/src/gatcha/requirements.txt
@@ -1,3 +1,5 @@
 Flask
 requests
 pymongo
+minio
+rich

--- a/src/gateway/app.py
+++ b/src/gateway/app.py
@@ -19,6 +19,7 @@ SERVICE_URLS = {
     'gatcha': os.getenv('GATCHA_URL'),
     'market': os.getenv('MARKET_URL'),
     'dbm': os.getenv('DBM_URL'),
+    'storage': os.getenv('MINIO_STORAGE_URL')
 }
 
 # TODO: aggiungere una WHITELIST con gli endpoint che possono essere chiamati da questo gateway (default deny). questo perché questo endpoint è pubblico. dobbiamo evitare che possa chiamare endpoint sensibili riservati agli admin.


### PR DESCRIPTION
Ho aggiunto, all'endpoint /gatcha/addgatchaData, il caricamento delle immagini.
In questo modo, quando un admin crea un nuovo matcha, può aggiungere un file (png / jpg) alla richiesta. Questo file verrà salvato sul bucket e il suo URL (pubblicamente accessibile) sarà salvato sul database.

Per fare ciò ho dovuto fare queste cose:
- creato un nuovo servizio "minio-storage", che si occupa dello storage dei file di immagine
- modificato matcha per potersi connettere al servizio mini-storage
- modificato l'endpoint addgatchaData per accettare una richiesta "multi-part" (JSON e file .png nella stessa richiesta)

Ho già creato questo test che dovrebbe controllare se la immagine è caricata correttamente, ma ancora non lo ho spostato negli integration tests:
![image](https://github.com/user-attachments/assets/fecf83f5-2c41-4134-9390-08435fa0fa63)
